### PR TITLE
Top the 'About' page

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ $ echo "make generate && git add docs/*" > .git/hooks/pre-commit
 $ chmod +x .git/hooks/pre-commit
 ```
 
+### About page
+
+We want the [About page](https://github.com/packit-service/packit.dev/blob/master/content/about.md)
+to be visible on the top of the website, so we have to keep the `date:` in the `about.md` newer then in the other content files.
+If you find a better way, let us know.
+
 ### Themes
 
 Currently, we use [Minos theme](https://themes.gohugo.io/hugo-theme-minos/).

--- a/config.toml
+++ b/config.toml
@@ -11,17 +11,17 @@ paginate = 5
 
 [menu]
   [[menu.main]]
-    name = "Posts"
-    pre = "<i class='fa fa-list fa-fw'></i>"
-    weight = 1
-    identifier = "posts"
-    url = "/posts/"
-  [[menu.main]]
     name = "About"
     pre = "<i class='fa fa-user fa-fw'></i>"
-    weight = 2
+    weight = 1
     identifier = "about"
     url = "/about/"
+  [[menu.main]]
+    name = "Posts"
+    pre = "<i class='fa fa-list fa-fw'></i>"
+    weight = 2
+    identifier = "posts"
+    url = "/posts/"
   [[menu.main]]
     name = "Source-git"
     pre = "<i class='fa fa-user fa-fw'></i>"

--- a/content/about.md
+++ b/content/about.md
@@ -1,6 +1,6 @@
 ---
 title: "About"
-date: 2019-03-22T18:13:04+01:00
+date: 2019-05-29
 draft: false
 ---
 

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -37,9 +37,9 @@
             <a id="logo" class="logo-text" href="https://packit.dev/">Packit</a>
             <nav id="main-nav">
                 
-                <a class="main-nav-link" href="/posts/">Posts</a>
-                
                 <a class="main-nav-link" href="/about/">About</a>
+                
+                <a class="main-nav-link" href="/posts/">Posts</a>
                 
                 <a class="main-nav-link" href="/source-git/">Source-git</a>
                 
@@ -62,7 +62,7 @@
         
         <div class="article-meta">
             <a href="/about/" class="article-date">
-                <time datetime='2019-03-22T18:13:04.000&#43;01:00' itemprop="datePublished">2019-03-22</time>
+                <time datetime='2019-05-29T00:00:00.000&#43;00:00' itemprop="datePublished">2019-05-29</time>
             </a>
             
             
@@ -190,15 +190,9 @@ dist-git the same way. We are not taking that away.
     </div>
     <nav id="article-nav">
     
-    <a href="/posts/packit-030/" id="article-nav-newer" class="article-nav-link-wrap">
-        <div class="article-nav-title"><span>&lt;</span>&nbsp;
-            Packit 0.3.0
-        </div>
-    </a>
     
-    
-    <a href="/posts/packit-020/" id="article-nav-older" class="article-nav-link-wrap">
-        <div class="article-nav-title">Packit 0.2.0 is here!&nbsp;<span>&gt;</span></div>
+    <a href="/posts/packit-041/" id="article-nav-older" class="article-nav-link-wrap">
+        <div class="article-nav-title">Packit 0.4.0 &amp; 0.4.1&nbsp;<span>&gt;</span></div>
     </a>
     
 </nav>

--- a/docs/categories/index.html
+++ b/docs/categories/index.html
@@ -36,9 +36,9 @@
             <a id="logo" class="logo-text" href="https://packit.dev/">Packit</a>
             <nav id="main-nav">
                 
-                <a class="main-nav-link" href="/posts/">Posts</a>
-                
                 <a class="main-nav-link" href="/about/">About</a>
+                
+                <a class="main-nav-link" href="/posts/">Posts</a>
                 
                 <a class="main-nav-link" href="/source-git/">Source-git</a>
                 

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,9 +36,9 @@
             <a id="logo" class="logo-text" href="https://packit.dev/">Packit</a>
             <nav id="main-nav">
                 
-                <a class="main-nav-link" href="/posts/">Posts</a>
-                
                 <a class="main-nav-link" href="/about/">About</a>
+                
+                <a class="main-nav-link" href="/posts/">Posts</a>
                 
                 <a class="main-nav-link" href="/source-git/">Source-git</a>
                 
@@ -58,83 +58,12 @@
                 
                 
                 <header class="article-header">
-                    <h1 itemprop="name"><a class="article-title" href="/posts/packit-041/">Packit 0.4.0 &amp; 0.4.1</a></h1>
-                </header>
-                
-                <div class="article-meta">
-                    <a href="/posts/packit-041/" class="article-date">
-                        <time datetime='2019-05-18T00:00:00.000&#43;00:00' itemprop="datePublished">2019-05-18</time>
-                    </a>
-                    
-                    
-                    
-                </div>
-                <div class="article-entry" itemprop="articleBody">
-                    <p>
-                        
-                    <p>It&rsquo;s been over a month since we released packit &ldquo;0.3.0&rdquo;. Here comes packit 0.4.0 (and patch release 0.4.1) and as always they bring a lot of new features and improvements.</p>
-
-<p>You can find a complete list in the
-<a href="https://github.com/packit-service/packit/blob/master/CHANGELOG.md#040">changelog</a>.</p>
-                    </p>
-                    <p class="article-more-link">
-                        <a href="/posts/packit-041/">Read More</a>
-                    </p>
-                </div>
-
-                
-            </div>
-        </article>
-        
-        <article class="article article-type-post" itemscope itemprop="blogPost">
-            <div class="article-inner">
-                
-                
-                <header class="article-header">
-                    <h1 itemprop="name"><a class="article-title" href="/posts/packit-030/">Packit 0.3.0</a></h1>
-                </header>
-                
-                <div class="article-meta">
-                    <a href="/posts/packit-030/" class="article-date">
-                        <time datetime='2019-04-11T00:00:00.000&#43;00:00' itemprop="datePublished">2019-04-11</time>
-                    </a>
-                    
-                    
-                    
-                </div>
-                <div class="article-entry" itemprop="articleBody">
-                    <p>
-                        
-                    <p>In the <a href="https://packit.dev/posts/packit-020/">previous post</a> we promised to
-provide a new release every 2 weeks and we are already breaking this promise as
-it&rsquo;s been 3 weeks since then. We decided to wait with the release to merge
-several pull requests related to source-git support.</p>
-
-<p>Now the good news. You can find a complete list of new features and
-improvements of version
-<a href="https://github.com/packit-service/packit/releases/tag/0.3.0">0.3.0</a> in the
-<a href="https://github.com/packit-service/packit/blob/master/CHANGELOG.md#030">changelog</a>.</p>
-                    </p>
-                    <p class="article-more-link">
-                        <a href="/posts/packit-030/">Read More</a>
-                    </p>
-                </div>
-
-                
-            </div>
-        </article>
-        
-        <article class="article article-type-post" itemscope itemprop="blogPost">
-            <div class="article-inner">
-                
-                
-                <header class="article-header">
                     <h1 itemprop="name"><a class="article-title" href="/about/">About</a></h1>
                 </header>
                 
                 <div class="article-meta">
                     <a href="/about/" class="article-date">
-                        <time datetime='2019-03-22T18:13:04.000&#43;01:00' itemprop="datePublished">2019-03-22</time>
+                        <time datetime='2019-05-29T00:00:00.000&#43;00:00' itemprop="datePublished">2019-05-29</time>
                     </a>
                     
                     
@@ -204,6 +133,77 @@ reproduce a bot locally on their machine, given appropriate credentials.</p></li
                     </p>
                     <p class="article-more-link">
                         <a href="/about/">Read More</a>
+                    </p>
+                </div>
+
+                
+            </div>
+        </article>
+        
+        <article class="article article-type-post" itemscope itemprop="blogPost">
+            <div class="article-inner">
+                
+                
+                <header class="article-header">
+                    <h1 itemprop="name"><a class="article-title" href="/posts/packit-041/">Packit 0.4.0 &amp; 0.4.1</a></h1>
+                </header>
+                
+                <div class="article-meta">
+                    <a href="/posts/packit-041/" class="article-date">
+                        <time datetime='2019-05-18T00:00:00.000&#43;00:00' itemprop="datePublished">2019-05-18</time>
+                    </a>
+                    
+                    
+                    
+                </div>
+                <div class="article-entry" itemprop="articleBody">
+                    <p>
+                        
+                    <p>It&rsquo;s been over a month since we released packit &ldquo;0.3.0&rdquo;. Here comes packit 0.4.0 (and patch release 0.4.1) and as always they bring a lot of new features and improvements.</p>
+
+<p>You can find a complete list in the
+<a href="https://github.com/packit-service/packit/blob/master/CHANGELOG.md#040">changelog</a>.</p>
+                    </p>
+                    <p class="article-more-link">
+                        <a href="/posts/packit-041/">Read More</a>
+                    </p>
+                </div>
+
+                
+            </div>
+        </article>
+        
+        <article class="article article-type-post" itemscope itemprop="blogPost">
+            <div class="article-inner">
+                
+                
+                <header class="article-header">
+                    <h1 itemprop="name"><a class="article-title" href="/posts/packit-030/">Packit 0.3.0</a></h1>
+                </header>
+                
+                <div class="article-meta">
+                    <a href="/posts/packit-030/" class="article-date">
+                        <time datetime='2019-04-11T00:00:00.000&#43;00:00' itemprop="datePublished">2019-04-11</time>
+                    </a>
+                    
+                    
+                    
+                </div>
+                <div class="article-entry" itemprop="articleBody">
+                    <p>
+                        
+                    <p>In the <a href="https://packit.dev/posts/packit-020/">previous post</a> we promised to
+provide a new release every 2 weeks and we are already breaking this promise as
+it&rsquo;s been 3 weeks since then. We decided to wait with the release to merge
+several pull requests related to source-git support.</p>
+
+<p>Now the good news. You can find a complete list of new features and
+improvements of version
+<a href="https://github.com/packit-service/packit/releases/tag/0.3.0">0.3.0</a> in the
+<a href="https://github.com/packit-service/packit/blob/master/CHANGELOG.md#030">changelog</a>.</p>
+                    </p>
+                    <p class="article-more-link">
+                        <a href="/posts/packit-030/">Read More</a>
                     </p>
                 </div>
 

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -6,44 +6,15 @@
     <description>Recent content on Packit</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Sat, 18 May 2019 00:00:00 +0000</lastBuildDate>
+    <lastBuildDate>Wed, 29 May 2019 00:00:00 +0000</lastBuildDate>
     
 	<atom:link href="https://packit.dev/index.xml" rel="self" type="application/rss+xml" />
     
     
     <item>
-      <title>Packit 0.4.0 &amp; 0.4.1</title>
-      <link>https://packit.dev/posts/packit-041/</link>
-      <pubDate>Sat, 18 May 2019 00:00:00 +0000</pubDate>
-      
-      <guid>https://packit.dev/posts/packit-041/</guid>
-      <description>&lt;p&gt;It&amp;rsquo;s been over a month since we released packit &amp;ldquo;0.3.0&amp;rdquo;. Here comes packit 0.4.0 (and patch release 0.4.1) and as always they bring a lot of new features and improvements.&lt;/p&gt;
-
-&lt;p&gt;You can find a complete list in the
-&lt;a href=&#34;https://github.com/packit-service/packit/blob/master/CHANGELOG.md#040&#34;&gt;changelog&lt;/a&gt;.&lt;/p&gt;</description>
-    </item>
-    
-    <item>
-      <title>Packit 0.3.0</title>
-      <link>https://packit.dev/posts/packit-030/</link>
-      <pubDate>Thu, 11 Apr 2019 00:00:00 +0000</pubDate>
-      
-      <guid>https://packit.dev/posts/packit-030/</guid>
-      <description>&lt;p&gt;In the &lt;a href=&#34;https://packit.dev/posts/packit-020/&#34;&gt;previous post&lt;/a&gt; we promised to
-provide a new release every 2 weeks and we are already breaking this promise as
-it&amp;rsquo;s been 3 weeks since then. We decided to wait with the release to merge
-several pull requests related to source-git support.&lt;/p&gt;
-
-&lt;p&gt;Now the good news. You can find a complete list of new features and
-improvements of version
-&lt;a href=&#34;https://github.com/packit-service/packit/releases/tag/0.3.0&#34;&gt;0.3.0&lt;/a&gt; in the
-&lt;a href=&#34;https://github.com/packit-service/packit/blob/master/CHANGELOG.md#030&#34;&gt;changelog&lt;/a&gt;.&lt;/p&gt;</description>
-    </item>
-    
-    <item>
       <title>About</title>
       <link>https://packit.dev/about/</link>
-      <pubDate>Fri, 22 Mar 2019 18:13:04 +0100</pubDate>
+      <pubDate>Wed, 29 May 2019 00:00:00 +0000</pubDate>
       
       <guid>https://packit.dev/about/</guid>
       <description>&lt;p&gt;Packit provides tooling and automation to integrate upstream open source projects into Fedora operating system.&lt;/p&gt;
@@ -104,6 +75,35 @@ completely automated.&lt;/p&gt;&lt;/li&gt;
 tester, or other engineer. Any Fedora developer or tester should be able to
 reproduce a bot locally on their machine, given appropriate credentials.&lt;/p&gt;&lt;/li&gt;
 &lt;/ul&gt;</description>
+    </item>
+    
+    <item>
+      <title>Packit 0.4.0 &amp; 0.4.1</title>
+      <link>https://packit.dev/posts/packit-041/</link>
+      <pubDate>Sat, 18 May 2019 00:00:00 +0000</pubDate>
+      
+      <guid>https://packit.dev/posts/packit-041/</guid>
+      <description>&lt;p&gt;It&amp;rsquo;s been over a month since we released packit &amp;ldquo;0.3.0&amp;rdquo;. Here comes packit 0.4.0 (and patch release 0.4.1) and as always they bring a lot of new features and improvements.&lt;/p&gt;
+
+&lt;p&gt;You can find a complete list in the
+&lt;a href=&#34;https://github.com/packit-service/packit/blob/master/CHANGELOG.md#040&#34;&gt;changelog&lt;/a&gt;.&lt;/p&gt;</description>
+    </item>
+    
+    <item>
+      <title>Packit 0.3.0</title>
+      <link>https://packit.dev/posts/packit-030/</link>
+      <pubDate>Thu, 11 Apr 2019 00:00:00 +0000</pubDate>
+      
+      <guid>https://packit.dev/posts/packit-030/</guid>
+      <description>&lt;p&gt;In the &lt;a href=&#34;https://packit.dev/posts/packit-020/&#34;&gt;previous post&lt;/a&gt; we promised to
+provide a new release every 2 weeks and we are already breaking this promise as
+it&amp;rsquo;s been 3 weeks since then. We decided to wait with the release to merge
+several pull requests related to source-git support.&lt;/p&gt;
+
+&lt;p&gt;Now the good news. You can find a complete list of new features and
+improvements of version
+&lt;a href=&#34;https://github.com/packit-service/packit/releases/tag/0.3.0&#34;&gt;0.3.0&lt;/a&gt; in the
+&lt;a href=&#34;https://github.com/packit-service/packit/blob/master/CHANGELOG.md#030&#34;&gt;changelog&lt;/a&gt;.&lt;/p&gt;</description>
     </item>
     
     <item>

--- a/docs/page/2/index.html
+++ b/docs/page/2/index.html
@@ -36,9 +36,9 @@
             <a id="logo" class="logo-text" href="https://packit.dev/">Packit</a>
             <nav id="main-nav">
                 
-                <a class="main-nav-link" href="/posts/">Posts</a>
-                
                 <a class="main-nav-link" href="/about/">About</a>
+                
+                <a class="main-nav-link" href="/posts/">Posts</a>
                 
                 <a class="main-nav-link" href="/source-git/">Source-git</a>
                 

--- a/docs/posts/index.html
+++ b/docs/posts/index.html
@@ -36,9 +36,9 @@
             <a id="logo" class="logo-text" href="https://packit.dev/">Packit</a>
             <nav id="main-nav">
                 
-                <a class="main-nav-link" href="/posts/">Posts</a>
-                
                 <a class="main-nav-link" href="/about/">About</a>
+                
+                <a class="main-nav-link" href="/posts/">Posts</a>
                 
                 <a class="main-nav-link" href="/source-git/">Source-git</a>
                 

--- a/docs/posts/packit-010/index.html
+++ b/docs/posts/packit-010/index.html
@@ -37,9 +37,9 @@
             <a id="logo" class="logo-text" href="https://packit.dev/">Packit</a>
             <nav id="main-nav">
                 
-                <a class="main-nav-link" href="/posts/">Posts</a>
-                
                 <a class="main-nav-link" href="/about/">About</a>
+                
+                <a class="main-nav-link" href="/posts/">Posts</a>
                 
                 <a class="main-nav-link" href="/source-git/">Source-git</a>
                 

--- a/docs/posts/packit-020/index.html
+++ b/docs/posts/packit-020/index.html
@@ -37,9 +37,9 @@
             <a id="logo" class="logo-text" href="https://packit.dev/">Packit</a>
             <nav id="main-nav">
                 
-                <a class="main-nav-link" href="/posts/">Posts</a>
-                
                 <a class="main-nav-link" href="/about/">About</a>
+                
+                <a class="main-nav-link" href="/posts/">Posts</a>
                 
                 <a class="main-nav-link" href="/source-git/">Source-git</a>
                 
@@ -244,9 +244,9 @@ New upstream release: 0.1.0
     </div>
     <nav id="article-nav">
     
-    <a href="/about/" id="article-nav-newer" class="article-nav-link-wrap">
+    <a href="/posts/packit-030/" id="article-nav-newer" class="article-nav-link-wrap">
         <div class="article-nav-title"><span>&lt;</span>&nbsp;
-            About
+            Packit 0.3.0
         </div>
     </a>
     

--- a/docs/posts/packit-030/index.html
+++ b/docs/posts/packit-030/index.html
@@ -37,9 +37,9 @@
             <a id="logo" class="logo-text" href="https://packit.dev/">Packit</a>
             <nav id="main-nav">
                 
-                <a class="main-nav-link" href="/posts/">Posts</a>
-                
                 <a class="main-nav-link" href="/about/">About</a>
+                
+                <a class="main-nav-link" href="/posts/">Posts</a>
                 
                 <a class="main-nav-link" href="/source-git/">Source-git</a>
                 
@@ -141,8 +141,8 @@ master: 0.2.0
     </a>
     
     
-    <a href="/about/" id="article-nav-older" class="article-nav-link-wrap">
-        <div class="article-nav-title">About&nbsp;<span>&gt;</span></div>
+    <a href="/posts/packit-020/" id="article-nav-older" class="article-nav-link-wrap">
+        <div class="article-nav-title">Packit 0.2.0 is here!&nbsp;<span>&gt;</span></div>
     </a>
     
 </nav>

--- a/docs/posts/packit-041/index.html
+++ b/docs/posts/packit-041/index.html
@@ -37,9 +37,9 @@
             <a id="logo" class="logo-text" href="https://packit.dev/">Packit</a>
             <nav id="main-nav">
                 
-                <a class="main-nav-link" href="/posts/">Posts</a>
-                
                 <a class="main-nav-link" href="/about/">About</a>
+                
+                <a class="main-nav-link" href="/posts/">Posts</a>
                 
                 <a class="main-nav-link" href="/source-git/">Source-git</a>
                 
@@ -114,6 +114,12 @@
         
     </div>
     <nav id="article-nav">
+    
+    <a href="/about/" id="article-nav-newer" class="article-nav-link-wrap">
+        <div class="article-nav-title"><span>&lt;</span>&nbsp;
+            About
+        </div>
+    </a>
     
     
     <a href="/posts/packit-030/" id="article-nav-older" class="article-nav-link-wrap">

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -3,8 +3,13 @@
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   
   <url>
+    <loc>https://packit.dev/about/</loc>
+    <lastmod>2019-05-29T00:00:00+00:00</lastmod>
+  </url>
+  
+  <url>
     <loc>https://packit.dev/</loc>
-    <lastmod>2019-05-18T00:00:00+00:00</lastmod>
+    <lastmod>2019-05-29T00:00:00+00:00</lastmod>
     <priority>0</priority>
   </url>
   
@@ -22,11 +27,6 @@
   <url>
     <loc>https://packit.dev/posts/packit-030/</loc>
     <lastmod>2019-04-11T00:00:00+00:00</lastmod>
-  </url>
-  
-  <url>
-    <loc>https://packit.dev/about/</loc>
-    <lastmod>2019-03-22T18:13:04+01:00</lastmod>
   </url>
   
   <url>

--- a/docs/source-git/index.html
+++ b/docs/source-git/index.html
@@ -37,9 +37,9 @@
             <a id="logo" class="logo-text" href="https://packit.dev/">Packit</a>
             <nav id="main-nav">
                 
-                <a class="main-nav-link" href="/posts/">Posts</a>
-                
                 <a class="main-nav-link" href="/about/">About</a>
+                
+                <a class="main-nav-link" href="/posts/">Posts</a>
                 
                 <a class="main-nav-link" href="/source-git/">Source-git</a>
                 

--- a/docs/tags/index.html
+++ b/docs/tags/index.html
@@ -36,9 +36,9 @@
             <a id="logo" class="logo-text" href="https://packit.dev/">Packit</a>
             <nav id="main-nav">
                 
-                <a class="main-nav-link" href="/posts/">Posts</a>
-                
                 <a class="main-nav-link" href="/about/">About</a>
+                
+                <a class="main-nav-link" href="/posts/">Posts</a>
                 
                 <a class="main-nav-link" href="/source-git/">Source-git</a>
                 


### PR DESCRIPTION
I haven't found a better way how to make the About page the default one instead of the Posts.

The only way is to keep the date in the [about.md](https://github.com/packit-service/packit.dev/blob/master/content/about.md) newer than in the other content pages.